### PR TITLE
BATIAI-1777: Allowing cidrblock ingress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ module "aurora" {
   db_subnet_group_name    = var.subnet_group_name
   create_security_group   = true
   allowed_security_groups = var.allowed_security_groups
+  allowed_cidr_blocks     = var.security_group_allowed_cidrs
   security_group_egress_rules = {
     to_cidrs = {
       cidr_blocks = ["0.0.0.0/0"]

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "allowed_security_groups" {
   type = list(string)
 }
 
+variable "security_group_allowed_cidrs" {
+  type    = list(string)
+  default = []
+}
+
 variable "master_username" {}
 variable "database_name" {}
 


### PR DESCRIPTION
## Fixes Issue: [BATIAI-1777](https://jiraent.cms.gov/browse/BATIAI-1777)

## Description:


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [x] Is there an impact on Communication Security procedures or capabilities?
   - This enables configuration to set additional cidrblocks for accessing the database directly. This runs the risk of misconfiguration, so we need to make sure this feature is only used in dev environments.
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.